### PR TITLE
Refine and trick-out landing page professional titles

### DIFF
--- a/components/landing-title/arcane.module.css
+++ b/components/landing-title/arcane.module.css
@@ -842,79 +842,52 @@
 }
 
 @media (max-width: 640px) {
-  .deck {
-    grid-template-columns: 1fr;
-    justify-items: start;
-  }
-
-  .deckCounter {
-    justify-self: start;
-  }
-
   .headlineWrap {
-    grid-template-columns: 1fr;
+    align-items: center !important;
+    text-align: center !important;
   }
 
-  .sceneMystic .sceneBody {
-    grid-template-columns: 1fr;
-    gap: 0.8rem;
-  }
-
+  /* All scenes: single column */
   .sceneSorcerer .sceneBody,
-  .sceneMage .sceneBody {
+  .sceneMage .sceneBody,
+  .sceneWeaver .sceneBody,
+  .sceneConjurer .sceneBody,
+  .sceneMystic .sceneBody,
+  .sceneOracle .sceneBody {
     grid-template-columns: 1fr;
-    gap: 0.8rem;
+    gap: 2rem;
   }
 
   .sceneSorcerer .titleBlock,
-  .sceneMage .titleBlock {
-    justify-self: center;
-    max-width: none;
-    padding: 0;
-    text-align: center;
-  }
-
-  .sceneSorcerer .headlineWrap,
-  .sceneMage .headlineWrap,
-  .sceneMystic .headlineWrap {
-    justify-items: center;
-  }
-
-  .sceneSorcerer .titleLockup,
-  .sceneSorcerer .descriptor,
-  .sceneMage .titleLockup,
-  .sceneMage .descriptor {
-    max-width: none;
+  .sceneMage .titleBlock,
+  .sceneConjurer .titleBlock {
+    order: 1; /* Title above rig on mobile */
   }
 
   .sceneSorcerer .sceneRig,
-  .sceneMage .sceneRig {
-    width: 100%;
-    min-height: 12rem;
+  .sceneMage .sceneRig,
+  .sceneConjurer .sceneRig {
+    order: 2;
   }
 
-  .sceneMystic .titleBlock {
-    padding: 0;
+  /* All titles: centered */
+  .titleBlock {
+    justify-self: center;
+    max-width: none;
+    padding-left: 0;
+    padding-right: 0;
     text-align: center;
   }
 
-  .sceneMystic .titleBlock::after {
-    display: none;
-  }
-
-  .sceneMystic .headlineWrap {
-    justify-items: center;
-  }
-
-  .sceneMystic .titleLockup,
-  .sceneMystic .descriptor {
-    max-width: none;
-  }
-
-  .sceneMystic .sceneRig {
+  /* All rigs: full width, compact */
+  .sceneSorcerer .sceneRig,
+  .sceneMage .sceneRig,
+  .sceneWeaver .sceneRig,
+  .sceneConjurer .sceneRig,
+  .sceneMystic .sceneRig,
+  .sceneOracle .sceneRig {
     width: 100%;
-    justify-self: center;
-    min-height: 12rem;
+    min-height: 14rem;
   }
 
   .sorcererTablet:nth-child(1) {

--- a/components/landing-title/arcane.tsx
+++ b/components/landing-title/arcane.tsx
@@ -225,46 +225,17 @@ function getSceneVars(themeConfig: SubtitleTheme, isDark: boolean): CSSPropertie
   } as CSSProperties;
 }
 
-function ArcaneDeck({
-  themeConfig,
-  notes,
-  positionLabel,
-  totalLabel,
-}: {
-  themeConfig: SubtitleTheme;
-  notes: readonly string[];
-  positionLabel: string;
-  totalLabel: string;
-}) {
-  return (
-    <div className={styles.deck} aria-hidden="true">
-      <span className={styles.deckFamily}>{themeConfig.signalDeck.family}</span>
-      <div className={styles.deckNotes}>
-        {notes.map((note) => (
-          <span key={`${themeConfig.id}-${note}`} className={styles.deckNote}>
-            {note}
-          </span>
-        ))}
-      </div>
-      <span className={styles.deckCounter}>
-        {positionLabel}
-        <span className={styles.deckCounterTotal}>/ {totalLabel}</span>
-      </span>
-    </div>
-  );
-}
-
 function ArcaneScene({
   config,
   context,
-  hideSignalDeck,
+
   onBlur,
   onFocus,
   onMouseEnter,
   onMouseLeave,
-  positionLabel,
+
   rotationStatusLabel,
-  totalLabel,
+
 }: SubtitleRendererShellProps & { config: ArcaneVariantConfig }) {
   const themeConfig = config.theme;
   const Icon = themeConfig.icon;
@@ -299,25 +270,14 @@ function ArcaneScene({
           })}
           data-motion={context.shouldAnimateTagline ? 'animated' : 'reduced'}
         >
-          {!hideSignalDeck ? (
-            <ArcaneDeck
-              themeConfig={themeConfig}
-              notes={config.notes}
-              positionLabel={positionLabel}
-              totalLabel={totalLabel}
-            />
-          ) : null}
-
           <div className={styles.sceneBody}>
             <div className={styles.titleBlock}>
-              <span className={styles.kicker}>{config.kicker}</span>
               <div className={styles.headlineWrap}>
                 <span className={styles.iconBadge} aria-hidden="true">
                   <Icon className={styles.icon} />
                 </span>
                 <div className={styles.titleLockup}>
                   <h2 className={styles.title}>{themeConfig.text}</h2>
-                  <p className={styles.descriptor}>{config.descriptor}</p>
                 </div>
               </div>
             </div>

--- a/components/landing-title/crafted.module.css
+++ b/components/landing-title/crafted.module.css
@@ -929,75 +929,52 @@
 /* ─── Responsive ──────────────────────────────────────────────────────────── */
 
 @media (max-width: 640px) {
-  .deck {
-    grid-template-columns: 1fr;
-    justify-items: start;
-  }
-
-  .deckCounter {
-    justify-self: start;
-  }
-
   .headlineWrap {
-    grid-template-columns: 1fr;
+    align-items: center !important;
+    text-align: center !important;
   }
 
-  .sceneBlockchain .sceneBody {
-    grid-template-columns: 1fr;
-    gap: 0.85rem;
-  }
-
+  /* All scenes: single column */
+  .sceneAlchemist .sceneBody,
   .sceneDigitalSculptor .sceneBody,
+  .sceneHolographicSculptor .sceneBody,
+  .sceneCyberDefense .sceneBody,
+  .sceneBlockchain .sceneBody,
   .sceneFrontier .sceneBody {
     grid-template-columns: 1fr;
-    gap: 0.85rem;
+    gap: 2rem;
   }
 
+  .sceneAlchemist .titleBlock,
+  .sceneCyberDefense .titleBlock,
   .sceneBlockchain .titleBlock {
-    padding: 0;
-    text-align: center;
+    order: 1; /* Title above rig on mobile */
   }
 
-  .sceneDigitalSculptor .titleBlock,
-  .sceneFrontier .titleBlock {
+  .sceneAlchemist .sceneRig,
+  .sceneCyberDefense .sceneRig,
+  .sceneBlockchain .sceneRig {
+    order: 2;
+  }
+
+  /* All titles: centered */
+  .titleBlock {
     justify-self: center;
     max-width: none;
+    padding-left: 0;
+    padding-right: 0;
     text-align: center;
   }
 
-  .sceneBlockchain .titleBlock::after {
-    display: none;
-  }
-
-  .sceneBlockchain .headlineWrap {
-    justify-items: center;
-  }
-
-  .sceneDigitalSculptor .headlineWrap,
-  .sceneFrontier .headlineWrap {
-    justify-items: center;
-  }
-
-  .sceneBlockchain .titleLockup,
-  .sceneBlockchain .descriptor {
-    max-width: none;
-  }
-
-  .sceneDigitalSculptor .titleLockup,
-  .sceneDigitalSculptor .descriptor,
-  .sceneFrontier .titleLockup,
-  .sceneFrontier .descriptor {
-    max-width: none;
-  }
-
-  .sceneBlockchain .sceneRig {
-    min-height: 12rem;
-  }
-
+  /* All rigs: full width, compact */
+  .sceneAlchemist .sceneRig,
   .sceneDigitalSculptor .sceneRig,
+  .sceneHolographicSculptor .sceneRig,
+  .sceneCyberDefense .sceneRig,
+  .sceneBlockchain .sceneRig,
   .sceneFrontier .sceneRig {
     width: 100%;
-    min-height: 12rem;
+    min-height: 14rem;
   }
 
   .alchemistAlembic {

--- a/components/landing-title/crafted.tsx
+++ b/components/landing-title/crafted.tsx
@@ -226,46 +226,17 @@ function getSceneVars(themeConfig: SubtitleTheme, isDark: boolean): CSSPropertie
   } as CSSProperties;
 }
 
-function CraftedDeck({
-  themeConfig,
-  notes,
-  positionLabel,
-  totalLabel,
-}: {
-  themeConfig: SubtitleTheme;
-  notes: readonly string[];
-  positionLabel: string;
-  totalLabel: string;
-}) {
-  return (
-    <div className={styles.deck} aria-hidden="true">
-      <span className={styles.deckFamily}>{themeConfig.signalDeck.family}</span>
-      <div className={styles.deckNotes}>
-        {notes.map((note) => (
-          <span key={`${themeConfig.id}-${note}`} className={styles.deckNote}>
-            {note}
-          </span>
-        ))}
-      </div>
-      <span className={styles.deckCounter}>
-        {positionLabel}
-        <span className={styles.deckCounterTotal}>/ {totalLabel}</span>
-      </span>
-    </div>
-  );
-}
-
 function CraftedScene({
   config,
   context,
-  hideSignalDeck,
+
   onBlur,
   onFocus,
   onMouseEnter,
   onMouseLeave,
-  positionLabel,
+
   rotationStatusLabel,
-  totalLabel,
+
 }: SubtitleRendererShellProps & { config: CraftedVariantConfig }) {
   const themeConfig = config.theme;
   const Icon = themeConfig.icon;
@@ -300,25 +271,14 @@ function CraftedScene({
           })}
           data-motion={context.shouldAnimateTagline ? 'animated' : 'reduced'}
         >
-          {!hideSignalDeck ? (
-            <CraftedDeck
-              themeConfig={themeConfig}
-              notes={config.notes}
-              positionLabel={positionLabel}
-              totalLabel={totalLabel}
-            />
-          ) : null}
-
           <div className={styles.sceneBody}>
             <div className={styles.titleBlock}>
-              <span className={styles.kicker}>{config.kicker}</span>
               <div className={styles.headlineWrap}>
                 <span className={styles.iconBadge} aria-hidden="true">
                   <Icon className={styles.icon} />
                 </span>
                 <div className={styles.titleLockup}>
                   <h2 className={styles.title}>{themeConfig.text}</h2>
-                  <p className={styles.descriptor}>{config.descriptor}</p>
                 </div>
               </div>
             </div>

--- a/components/landing-title/performance.module.css
+++ b/components/landing-title/performance.module.css
@@ -1,4 +1,4 @@
-/* ─── Shell ──────────────────────────────────────────────────────────────────── */
+
 
 .cluster {
   width: 100%;
@@ -56,237 +56,102 @@
   background: linear-gradient(90deg, transparent, var(--perf-edge), transparent);
 }
 
-/* ─── Scene-specific padding & layout ────────────────────────────────────────── */
+/* ─── Scene body layout overrides ────────────────────────────────────────────── */
 
-.sceneAutomation,
-.sceneRobotics,
-.sceneNeural {
-  padding: 1rem 1rem 1.15rem;
-}
-
-/* Automation: title LEFT, rig RIGHT */
-
-.sceneAutomation .sceneBody {
-  grid-template-columns: minmax(0, 10.5rem) minmax(0, 1fr);
-  align-items: center;
-  min-height: 15rem;
-  gap: 0.55rem;
-}
-
-.sceneAutomation .titleBlock {
-  max-width: 10.2rem;
-  padding-left: 0.1rem;
-  z-index: 2;
-}
-
-.sceneAutomation .headlineWrap {
-  grid-template-columns: 1fr;
-  justify-items: start;
-}
-
-.sceneAutomation .iconBadge {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.85rem;
-}
-
-.sceneAutomation .titleLockup,
-.sceneAutomation .descriptor {
-  max-width: 10rem;
-}
-
-.sceneAutomation .sceneRig {
-  min-height: 14rem;
-  border: none;
-  background:
-    radial-gradient(circle at 50% 44%, var(--perf-glow-soft), transparent 44%),
-    linear-gradient(160deg, var(--perf-subtle-fill), transparent);
-  overflow: visible;
-}
-
-/* Robotics: rig LEFT, title RIGHT */
-
-.sceneRobotics .sceneBody {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 10rem);
-  align-items: center;
-  min-height: 15rem;
-  gap: 0.55rem;
-}
-
-.sceneRobotics .titleBlock {
-  order: 2;
-  max-width: 9.8rem;
-  justify-self: end;
-  z-index: 2;
-}
-
-.sceneRobotics .headlineWrap {
-  grid-template-columns: 1fr;
-  justify-items: start;
-}
-
-.sceneRobotics .iconBadge {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.85rem;
-}
-
-.sceneRobotics .titleLockup,
-.sceneRobotics .descriptor {
-  max-width: 9.6rem;
-}
-
-.sceneRobotics .sceneRig {
-  order: 1;
-  min-height: 14rem;
-  border: none;
-  background: none;
-  overflow: visible;
-}
-
-/* Neural: title LEFT (narrow), rig RIGHT (wider) */
-
-.sceneNeural .sceneBody {
-  grid-template-columns: minmax(0, 9.5rem) minmax(0, 1fr);
-  align-items: center;
-  min-height: 15rem;
-  gap: 0.5rem;
-}
-
-.sceneNeural .titleBlock {
-  max-width: 9.2rem;
-  padding-left: 0.1rem;
-  z-index: 2;
-}
-
-.sceneNeural .headlineWrap {
-  grid-template-columns: 1fr;
-  justify-items: start;
-}
-
-.sceneNeural .iconBadge {
-  display: none;
-}
-
-.sceneNeural .titleLockup,
-.sceneNeural .descriptor {
-  max-width: 9rem;
-}
-
-.sceneNeural .sceneRig {
-  min-height: 14rem;
-  border: none;
-  background: none;
-  overflow: visible;
-  display: grid;
-  place-items: center;
-}
-
-/* ─── Deck ───────────────────────────────────────────────────────────────────── */
-
-.deck {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: 0.8rem;
-  margin-bottom: 0.95rem;
-  color: var(--perf-muted);
-  font-size: 0.63rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-}
-
-.deckFamily,
-.deckCounter {
-  white-space: nowrap;
-}
-
-.deckCounter {
-  justify-self: end;
-}
-
-.deckCounterTotal {
-  opacity: 0.65;
-}
-
-.deckNotes {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.38rem;
-}
-
-.deckNote {
-  border-radius: 999px;
-  border: 1px solid var(--perf-edge);
-  background: var(--perf-subtle-fill);
-  padding: 0.2rem 0.5rem;
-}
-
-/* ─── Title & content ────────────────────────────────────────────────────────── */
-
+/* Scene grids focus entirely on visual impact */
 .sceneBody {
   display: grid;
-  gap: 1rem;
+  align-items: center;
+  min-height: 16rem; /* Enlarge slightly to let design shine */
+  gap: 2rem;
 }
+
+.sceneAutomation .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneRobotics .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneNeural .sceneBody { grid-template-columns: 1.5fr 1fr; }
+
+/* In automation, robotics: text is second element in code, rig is first */
+.sceneAutomation .titleBlock,
+.sceneRobotics .titleBlock {
+  order: 2;
+}
+
+.sceneAutomation .sceneRig,
+.sceneRobotics .sceneRig {
+  order: 1;
+}
+
+/* ─── Scene body / title block ─────────────────────────────────────────── */
 
 .titleBlock {
-  display: grid;
-  gap: 0.55rem;
-}
-
-.kicker {
-  color: var(--perf-muted);
-  font-size: 0.66rem;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  z-index: 2;
 }
 
 .headlineWrap {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.85rem;
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+/* Adjustments for layouts with rig left/right */
+.sceneAutomation .headlineWrap,
+.sceneRobotics .headlineWrap {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.sceneNeural .headlineWrap {
+  align-items: flex-start;
+  text-align: left;
 }
 
 .iconBadge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 1rem;
+  width: 4.5rem; /* much larger */
+  height: 4.5rem;
+  border-radius: 1.25rem;
   border: 1px solid var(--perf-edge);
   background:
-    linear-gradient(160deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04)),
+    linear-gradient(160deg, var(--perf-fill-strong), var(--perf-fill)),
     var(--perf-gradient);
-  box-shadow: 0 18px 34px var(--perf-glow-soft);
+  box-shadow: 0 24px 48px var(--perf-glow-soft);
+  margin-bottom: 0.5rem;
+}
+
+.sceneNeural .iconBadge {
+  display: none;
 }
 
 .icon {
-  width: 1.4rem;
-  height: 1.4rem;
+  width: 2.2rem;
+  height: 2.2rem;
+  color: #fff;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
 }
 
 .titleLockup {
-  display: grid;
-  gap: 0.42rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .title {
   margin: 0;
-  font-size: clamp(1.45rem, 3vw, 2.2rem);
-  line-height: 0.94;
-  letter-spacing: -0.035em;
+  font-size: clamp(2rem, 4.5vw, 3.2rem); /* Significantly enlarged */
+  line-height: 1.05;
+  letter-spacing: -0.04em;
   text-wrap: balance;
-}
-
-.descriptor {
-  margin: 0;
-  max-width: 30rem;
-  color: var(--perf-muted);
-  font-size: 0.87rem;
-  line-height: 1.5;
+  text-shadow: 0 10px 30px var(--perf-glow-soft), 0 2px 4px rgba(0,0,0,0.5); /* Glowing and poppy text */
+  font-weight: 800;
+  background: linear-gradient(to bottom right, #fff, var(--perf-edge));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 /* ─── Scene rig (base) ───────────────────────────────────────────────────────── */
@@ -710,54 +575,43 @@
 /* ─── Mobile ─────────────────────────────────────────────────────────────────── */
 
 @media (max-width: 640px) {
-  .deck {
-    grid-template-columns: 1fr;
-    justify-items: start;
-  }
-
-  .deckCounter {
-    justify-self: start;
-  }
-
   .headlineWrap {
-    grid-template-columns: 1fr;
+    align-items: center !important;
+    text-align: center !important;
   }
 
+  /* All scenes: single column */
   .sceneAutomation .sceneBody,
   .sceneRobotics .sceneBody,
   .sceneNeural .sceneBody {
     grid-template-columns: 1fr;
-    gap: 0.85rem;
+    gap: 2rem;
   }
 
   .sceneAutomation .titleBlock,
-  .sceneRobotics .titleBlock,
-  .sceneNeural .titleBlock {
+  .sceneRobotics .titleBlock {
+    order: 1; /* Title above rig on mobile */
+  }
+
+  .sceneAutomation .sceneRig,
+  .sceneRobotics .sceneRig {
+    order: 2;
+  }
+
+  /* All titles: centered */
+  .titleBlock {
     justify-self: center;
     max-width: none;
     padding-left: 0;
+    padding-right: 0;
     text-align: center;
   }
 
-  .sceneAutomation .headlineWrap,
-  .sceneRobotics .headlineWrap,
-  .sceneNeural .headlineWrap {
-    justify-items: center;
-  }
-
-  .sceneAutomation .titleLockup,
-  .sceneAutomation .descriptor,
-  .sceneRobotics .titleLockup,
-  .sceneRobotics .descriptor,
-  .sceneNeural .titleLockup,
-  .sceneNeural .descriptor {
-    max-width: none;
-  }
-
+  /* All rigs: full width, compact */
   .sceneAutomation .sceneRig,
   .sceneRobotics .sceneRig,
   .sceneNeural .sceneRig {
     width: 100%;
-    min-height: 12rem;
+    min-height: 14rem;
   }
 }

--- a/components/landing-title/performance.tsx
+++ b/components/landing-title/performance.tsx
@@ -147,46 +147,17 @@ function getSceneVars(themeConfig: SubtitleTheme, isDark: boolean): CSSPropertie
   } as CSSProperties;
 }
 
-function PerformanceDeck({
-  themeConfig,
-  notes,
-  positionLabel,
-  totalLabel,
-}: {
-  themeConfig: SubtitleTheme;
-  notes: readonly string[];
-  positionLabel: string;
-  totalLabel: string;
-}) {
-  return (
-    <div className={styles.deck} aria-hidden="true">
-      <span className={styles.deckFamily}>{themeConfig.signalDeck.family}</span>
-      <div className={styles.deckNotes}>
-        {notes.map((note) => (
-          <span key={`${themeConfig.id}-${note}`} className={styles.deckNote}>
-            {note}
-          </span>
-        ))}
-      </div>
-      <span className={styles.deckCounter}>
-        {positionLabel}
-        <span className={styles.deckCounterTotal}>/ {totalLabel}</span>
-      </span>
-    </div>
-  );
-}
-
 function PerformanceScene({
   config,
   context,
-  hideSignalDeck,
+
   onBlur,
   onFocus,
   onMouseEnter,
   onMouseLeave,
-  positionLabel,
+
   rotationStatusLabel,
-  totalLabel,
+
 }: SubtitleRendererShellProps & { config: PerformanceVariantConfig }) {
   const themeConfig = config.theme;
   const Icon = themeConfig.icon;
@@ -219,25 +190,14 @@ function PerformanceScene({
           })}
           data-motion={context.shouldAnimateTagline ? 'animated' : 'reduced'}
         >
-          {!hideSignalDeck ? (
-            <PerformanceDeck
-              themeConfig={themeConfig}
-              notes={config.notes}
-              positionLabel={positionLabel}
-              totalLabel={totalLabel}
-            />
-          ) : null}
-
           <div className={styles.sceneBody}>
             <div className={styles.titleBlock}>
-              <span className={styles.kicker}>{config.kicker}</span>
               <div className={styles.headlineWrap}>
                 <span className={styles.iconBadge} aria-hidden="true">
                   <Icon className={styles.icon} />
                 </span>
                 <div className={styles.titleLockup}>
                   <h2 className={styles.title}>{themeConfig.text}</h2>
-                  <p className={styles.descriptor}>{config.descriptor}</p>
                 </div>
               </div>
             </div>

--- a/components/landing-title/systems.module.css
+++ b/components/landing-title/systems.module.css
@@ -24,6 +24,14 @@
   outline: none;
 }
 
+.clusterCompact {
+  max-width: 31rem;
+}
+
+.control {
+  outline: none;
+}
+
 .control:focus-visible .scene {
   transform: translateY(-1px);
   box-shadow:
@@ -80,369 +88,112 @@
 
 /* ─── Scene body layout overrides ──────────────────────────────────────── */
 
-/* Cybernetic: title left, armor rig right */
-.sceneCybernetic .sceneBody {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 7.2rem);
+/* Scene grids focus entirely on visual impact */
+.sceneBody {
+  display: grid;
   align-items: center;
-  min-height: 15rem;
-  gap: 0.45rem;
+  min-height: 16rem; /* Enlarge slightly to let design shine */
+  gap: 2rem;
 }
 
-.sceneCybernetic .titleBlock {
-  max-width: 10.6rem;
-  padding-left: 0.1rem;
-  z-index: 2;
-}
+.sceneCybernetic .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneZeroTrust .sceneBody { grid-template-columns: 1.5fr 1fr; }
+.sceneSynthetic .sceneBody { grid-template-columns: 1fr 1fr; }
+.sceneQuantum .sceneBody { grid-template-columns: 1fr 1.2fr; }
+.sceneCloud .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneCartographer .sceneBody { grid-template-columns: 1.2fr 1fr; }
+.sceneOrchestrator .sceneBody { grid-template-columns: 1.5fr 1fr; }
 
-.sceneCybernetic .titleLockup,
-.sceneCybernetic .descriptor {
-  max-width: 10rem;
-}
-
-.sceneCybernetic .sceneRig {
-  min-height: 14rem;
-  border: none;
-  background: none;
-  overflow: visible;
-}
-
-/* Zero Trust: title left, vault rig right */
-.sceneZeroTrust .sceneBody {
-  grid-template-columns: minmax(0, 10rem) minmax(0, 1fr);
-  align-items: center;
-  min-height: 15rem;
-  gap: 0.5rem;
-}
-
-.sceneZeroTrust .titleBlock {
-  max-width: 9.6rem;
-  padding-left: 0.1rem;
-  z-index: 2;
-}
-
-.sceneZeroTrust .headlineWrap {
-  grid-template-columns: 1fr;
-  justify-items: start;
-}
-
-.sceneZeroTrust .iconBadge {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.85rem;
-}
-
-.sceneZeroTrust .titleLockup,
-.sceneZeroTrust .descriptor {
-  max-width: 9.2rem;
-}
-
-.sceneZeroTrust .sceneRig {
-  min-height: 14rem;
-  border: none;
-  background: none;
-  overflow: visible;
-}
-
-/* Synthetic: cortex rig left, title right */
-.sceneSynthetic .sceneBody {
-  grid-template-columns: minmax(0, 0.95fr) minmax(0, 0.9fr);
-  align-items: center;
-  min-height: 15rem;
-  gap: 0.5rem;
-}
-
-.sceneSynthetic .titleBlock {
-  order: 2;
-  max-width: 10.8rem;
-  justify-self: end;
-  z-index: 2;
-}
-
-.sceneSynthetic .headlineWrap {
-  grid-template-columns: 1fr;
-  justify-items: start;
-}
-
-.sceneSynthetic .iconBadge {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.85rem;
-}
-
-.sceneSynthetic .titleLockup,
-.sceneSynthetic .descriptor {
-  max-width: 10.4rem;
-}
-
-.sceneSynthetic .sceneRig {
-  order: 1;
-  min-height: 14rem;
-  border: none;
-  background: none;
-  overflow: visible;
-}
-
-/* Quantum: orbit rig left, title right */
-.sceneQuantum .sceneBody {
-  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
-  align-items: center;
-  min-height: 15rem;
-  gap: 0.55rem;
-}
-
-.sceneQuantum .titleBlock {
-  order: 2;
-  position: relative;
-  z-index: 2;
-  max-width: 13.75rem;
-  justify-self: end;
-  padding-right: 0.1rem;
-  text-align: left;
-}
-
-.sceneQuantum .headlineWrap {
-  grid-template-columns: 1fr;
-  justify-items: start;
-}
-
-.sceneQuantum .titleLockup,
-.sceneQuantum .descriptor {
-  max-width: 13rem;
-}
-
-.sceneQuantum .iconBadge {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.85rem;
-}
-
-.sceneQuantum .sceneRig {
-  order: 1;
-  min-height: 14rem;
-  border: none;
-  background: none;
-  overflow: visible;
-}
-
-/* Cloud: title left, cumulus rig right */
-.sceneCloud .sceneBody {
-  grid-template-columns: minmax(0, 8.8rem) minmax(0, 1fr);
-  align-items: stretch;
-  min-height: 15rem;
-  gap: 0.5rem;
-}
-
-.sceneCloud .titleBlock {
-  align-self: center;
-  max-width: 8.6rem;
-  padding-left: 0.1rem;
-  z-index: 2;
-}
-
-.sceneCloud .headlineWrap {
-  grid-template-columns: 1fr;
-  justify-items: start;
-}
-
-.sceneCloud .iconBadge {
-  display: none;
-}
-
-.sceneCloud .titleLockup,
-.sceneCloud .descriptor {
-  max-width: 8.2rem;
-}
-
-.sceneCloud .sceneRig {
-  min-height: 14rem;
-  border: none;
-  background: none;
-  overflow: visible;
-}
-
-/* Cartographer: atlas rig left, title right */
-.sceneCartographer .sceneBody {
-  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
-  align-items: center;
-  min-height: 15rem;
-  gap: 0.5rem;
-}
-
-.sceneCartographer .titleBlock {
-  order: 2;
-  max-width: 10rem;
-  justify-self: end;
-  z-index: 2;
-}
-
-.sceneCartographer .headlineWrap {
-  grid-template-columns: 1fr;
-  justify-items: start;
-}
-
-.sceneCartographer .iconBadge {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.85rem;
-}
-
-.sceneCartographer .titleLockup,
-.sceneCartographer .descriptor {
-  max-width: 9.6rem;
-}
-
-.sceneCartographer .sceneRig {
-  order: 1;
-  min-height: 14rem;
-  border: none;
-  background: none;
-  overflow: visible;
-}
-
-/* Orchestrator: score rig left, title right */
-.sceneOrchestrator .sceneBody {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 0.92fr);
-  align-items: center;
-  min-height: 15rem;
-  gap: 0.5rem;
-}
-
+/* In synthetic, quantum, cartographer, orchestrator: text is second element in code, rig is first */
+.sceneSynthetic .titleBlock,
+.sceneQuantum .titleBlock,
+.sceneCartographer .titleBlock,
 .sceneOrchestrator .titleBlock {
   order: 2;
-  max-width: 10rem;
-  justify-self: end;
-  z-index: 2;
 }
 
-.sceneOrchestrator .headlineWrap {
-  grid-template-columns: 1fr;
-  justify-items: start;
-}
-
-.sceneOrchestrator .iconBadge {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.85rem;
-}
-
-.sceneOrchestrator .titleLockup,
-.sceneOrchestrator .descriptor {
-  max-width: 9.8rem;
-}
-
+.sceneSynthetic .sceneRig,
+.sceneQuantum .sceneRig,
+.sceneCartographer .sceneRig,
 .sceneOrchestrator .sceneRig {
   order: 1;
-  min-height: 13.8rem;
-  border: none;
-  background: none;
-  overflow: visible;
-}
-
-/* ─── Deck ─────────────────────────────────────────────────────────────── */
-
-.deck {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: 0.8rem;
-  margin-bottom: 0.95rem;
-  color: var(--sys-muted);
-  font-size: 0.62rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-}
-
-.deckFamily,
-.deckCounter {
-  white-space: nowrap;
-}
-
-.deckCounter {
-  justify-self: end;
-}
-
-.deckCounterTotal {
-  opacity: 0.65;
-}
-
-.deckNotes {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.38rem;
-}
-
-.deckNote {
-  border-radius: 999px;
-  border: 1px solid var(--sys-edge);
-  background: var(--sys-struct);
-  padding: 0.22rem 0.5rem;
 }
 
 /* ─── Scene body / title block ─────────────────────────────────────────── */
 
-.sceneBody {
-  display: grid;
-  gap: 1rem;
-}
-
 .titleBlock {
-  display: grid;
-  gap: 0.55rem;
-}
-
-.kicker {
-  color: var(--sys-muted);
-  font-size: 0.66rem;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  z-index: 2;
 }
 
 .headlineWrap {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.85rem;
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+/* Adjustments for layouts with rig left/right */
+.sceneCybernetic .headlineWrap,
+.sceneCloud .headlineWrap {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.sceneZeroTrust .headlineWrap,
+.sceneSynthetic .headlineWrap,
+.sceneQuantum .headlineWrap,
+.sceneCartographer .headlineWrap,
+.sceneOrchestrator .headlineWrap {
+  align-items: flex-start;
+  text-align: left;
 }
 
 .iconBadge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 1rem;
+  width: 4.5rem; /* much larger */
+  height: 4.5rem;
+  border-radius: 1.25rem;
   border: 1px solid var(--sys-edge);
   background:
     linear-gradient(160deg, var(--sys-struct-strong), var(--sys-struct-faint)),
     var(--sys-gradient);
-  box-shadow: 0 18px 34px var(--sys-glow-soft);
+  box-shadow: 0 24px 48px var(--sys-glow-soft);
+  margin-bottom: 0.5rem;
+}
+
+.sceneCloud .iconBadge {
+  display: none;
 }
 
 .icon {
-  width: 1.35rem;
-  height: 1.35rem;
+  width: 2.2rem;
+  height: 2.2rem;
+  color: #fff;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
 }
 
 .titleLockup {
-  display: grid;
-  gap: 0.4rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .title {
   margin: 0;
-  font-size: clamp(1.42rem, 3vw, 2.16rem);
-  line-height: 0.96;
-  letter-spacing: -0.03em;
+  font-size: clamp(2rem, 4.5vw, 3.2rem); /* Significantly enlarged */
+  line-height: 1.05;
+  letter-spacing: -0.04em;
   text-wrap: balance;
-}
-
-.descriptor {
-  margin: 0;
-  max-width: 30rem;
-  color: var(--sys-muted);
-  font-size: 0.87rem;
-  line-height: 1.5;
+  text-shadow: 0 10px 30px var(--sys-glow-soft), 0 2px 4px rgba(0,0,0,0.5); /* Glowing and poppy text */
+  font-weight: 800;
+  background: linear-gradient(to bottom right, #fff, var(--sys-edge));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 /* ─── Rig base ─────────────────────────────────────────────────────────── */
@@ -1303,17 +1054,9 @@
 /* ─── Mobile ───────────────────────────────────────────────────────────── */
 
 @media (max-width: 640px) {
-  .deck {
-    grid-template-columns: 1fr;
-    justify-items: start;
-  }
-
-  .deckCounter {
-    justify-self: start;
-  }
-
   .headlineWrap {
-    grid-template-columns: 1fr;
+    align-items: center !important;
+    text-align: center !important;
   }
 
   /* All scenes: single column */
@@ -1325,49 +1068,30 @@
   .sceneCartographer .sceneBody,
   .sceneOrchestrator .sceneBody {
     grid-template-columns: 1fr;
-    gap: 0.8rem;
+    gap: 2rem;
+  }
+
+  .sceneSynthetic .titleBlock,
+  .sceneQuantum .titleBlock,
+  .sceneCartographer .titleBlock,
+  .sceneOrchestrator .titleBlock {
+    order: 1; /* Title above rig on mobile */
+  }
+
+  .sceneSynthetic .sceneRig,
+  .sceneQuantum .sceneRig,
+  .sceneCartographer .sceneRig,
+  .sceneOrchestrator .sceneRig {
+    order: 2;
   }
 
   /* All titles: centered */
-  .sceneCybernetic .titleBlock,
-  .sceneZeroTrust .titleBlock,
-  .sceneSynthetic .titleBlock,
-  .sceneQuantum .titleBlock,
-  .sceneCloud .titleBlock,
-  .sceneCartographer .titleBlock,
-  .sceneOrchestrator .titleBlock {
+  .titleBlock {
     justify-self: center;
     max-width: none;
     padding-left: 0;
     padding-right: 0;
     text-align: center;
-  }
-
-  .sceneCybernetic .headlineWrap,
-  .sceneZeroTrust .headlineWrap,
-  .sceneSynthetic .headlineWrap,
-  .sceneQuantum .headlineWrap,
-  .sceneCloud .headlineWrap,
-  .sceneCartographer .headlineWrap,
-  .sceneOrchestrator .headlineWrap {
-    justify-items: center;
-  }
-
-  .sceneCybernetic .titleLockup,
-  .sceneCybernetic .descriptor,
-  .sceneZeroTrust .titleLockup,
-  .sceneZeroTrust .descriptor,
-  .sceneSynthetic .titleLockup,
-  .sceneSynthetic .descriptor,
-  .sceneQuantum .titleLockup,
-  .sceneQuantum .descriptor,
-  .sceneCloud .titleLockup,
-  .sceneCloud .descriptor,
-  .sceneCartographer .titleLockup,
-  .sceneCartographer .descriptor,
-  .sceneOrchestrator .titleLockup,
-  .sceneOrchestrator .descriptor {
-    max-width: none;
   }
 
   /* All rigs: full width, compact */
@@ -1379,7 +1103,7 @@
   .sceneCartographer .sceneRig,
   .sceneOrchestrator .sceneRig {
     width: 100%;
-    min-height: 12rem;
+    min-height: 14rem;
   }
 
   /* Cybernetic mobile */

--- a/components/landing-title/systems.tsx
+++ b/components/landing-title/systems.tsx
@@ -246,46 +246,17 @@ function getSceneVars(themeConfig: SubtitleTheme, isDark: boolean): CSSPropertie
   } as CSSProperties;
 }
 
-function SystemsDeck({
-  themeConfig,
-  notes,
-  positionLabel,
-  totalLabel,
-}: {
-  themeConfig: SubtitleTheme;
-  notes: readonly string[];
-  positionLabel: string;
-  totalLabel: string;
-}) {
-  return (
-    <div className={styles.deck} aria-hidden="true">
-      <span className={styles.deckFamily}>{themeConfig.signalDeck.family}</span>
-      <div className={styles.deckNotes}>
-        {notes.map((note) => (
-          <span key={`${themeConfig.id}-${note}`} className={styles.deckNote}>
-            {note}
-          </span>
-        ))}
-      </div>
-      <span className={styles.deckCounter}>
-        {positionLabel}
-        <span className={styles.deckCounterTotal}>/ {totalLabel}</span>
-      </span>
-    </div>
-  );
-}
-
 function SystemsScene({
   config,
   context,
-  hideSignalDeck,
+
   onBlur,
   onFocus,
   onMouseEnter,
   onMouseLeave,
-  positionLabel,
+
   rotationStatusLabel,
-  totalLabel,
+
 }: SubtitleRendererShellProps & { config: SystemsVariantConfig }) {
   const themeConfig = config.theme;
   const Icon = themeConfig.icon;
@@ -321,25 +292,14 @@ function SystemsScene({
           })}
           data-motion={context.shouldAnimateTagline ? 'animated' : 'reduced'}
         >
-          {!hideSignalDeck ? (
-            <SystemsDeck
-              themeConfig={themeConfig}
-              notes={config.notes}
-              positionLabel={positionLabel}
-              totalLabel={totalLabel}
-            />
-          ) : null}
-
           <div className={styles.sceneBody}>
             <div className={styles.titleBlock}>
-              <span className={styles.kicker}>{config.kicker}</span>
               <div className={styles.headlineWrap}>
                 <span className={styles.iconBadge} aria-hidden="true">
                   <Icon className={styles.icon} />
                 </span>
                 <div className={styles.titleLockup}>
                   <h2 className={styles.title}>{themeConfig.text}</h2>
-                  <p className={styles.descriptor}>{config.descriptor}</p>
                 </div>
               </div>
             </div>

--- a/components/particles/configUrls.ts
+++ b/components/particles/configUrls.ts
@@ -1,5 +1,5 @@
 // This file is auto-generated. Do not edit manually.
-// Last generated: 2026-04-13T05:34:59.878Z
+// Last generated: 2026-04-13T09:53:49.321Z
 
 type ParticleConfig = {
   url: string;
@@ -13,31 +13,31 @@ export const configUrls: Record<'light' | 'dark', readonly ParticleConfig[]> = {
     {
       "url": "/particles/light/butterflies.json",
       "hash": "79b9173c82e66e1e67d459b27d6a3280",
-      "lastModified": "2026-03-15T23:31:26.558Z",
+      "lastModified": "2026-04-13T07:59:43.181Z",
       "theme": "light"
     },
     {
       "url": "/particles/light/flowers.json",
       "hash": "f3910aaaabf15780600772e0c71dd41b",
-      "lastModified": "2026-03-15T23:31:26.563Z",
+      "lastModified": "2026-04-13T07:59:43.181Z",
       "theme": "light"
     },
     {
       "url": "/particles/light/hex.json",
       "hash": "b2712fec4f7432d276e4d9002f83ddc9",
-      "lastModified": "2026-03-15T23:31:26.563Z",
+      "lastModified": "2026-04-13T07:59:43.181Z",
       "theme": "light"
     },
     {
       "url": "/particles/light/net.json",
       "hash": "62210349a37cfa380c9fafb5ec26f365",
-      "lastModified": "2026-03-15T23:31:26.563Z",
+      "lastModified": "2026-04-13T07:59:43.181Z",
       "theme": "light"
     },
     {
       "url": "/particles/light/snow.json",
       "hash": "35f3618a9f32b6111c7c9fee19bc5c52",
-      "lastModified": "2026-03-15T23:31:26.563Z",
+      "lastModified": "2026-04-13T07:59:43.181Z",
       "theme": "light"
     }
   ],
@@ -45,31 +45,31 @@ export const configUrls: Record<'light' | 'dark', readonly ParticleConfig[]> = {
     {
       "url": "/particles/dark/fireflies.json",
       "hash": "6bc88234259106eb406da58e7cc0775a",
-      "lastModified": "2026-03-15T23:31:26.555Z",
+      "lastModified": "2026-04-13T07:59:43.177Z",
       "theme": "dark"
     },
     {
       "url": "/particles/dark/galaxy.json",
       "hash": "3ee952a217df83b7eb40db6461ccb84b",
-      "lastModified": "2026-03-15T23:31:26.556Z",
+      "lastModified": "2026-04-13T07:59:43.177Z",
       "theme": "dark"
     },
     {
       "url": "/particles/dark/matrix.json",
       "hash": "a8d716f5a2288c07b41c4530e541f4e9",
-      "lastModified": "2026-03-15T23:31:26.556Z",
+      "lastModified": "2026-04-13T07:59:43.177Z",
       "theme": "dark"
     },
     {
       "url": "/particles/dark/nebula.json",
       "hash": "158f98abaa49f324d5ed0c78185eb638",
-      "lastModified": "2026-03-15T23:31:26.557Z",
+      "lastModified": "2026-04-13T07:59:43.177Z",
       "theme": "dark"
     },
     {
       "url": "/particles/dark/stars.json",
       "hash": "4b241eba6c2a1364f28d8d121d651859",
-      "lastModified": "2026-03-15T23:31:26.557Z",
+      "lastModified": "2026-04-13T07:59:43.177Z",
       "theme": "dark"
     }
   ]

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,289 @@
+--- components/landing-title/performance.module.css
++++ components/landing-title/performance.module.css
+@@ -53,91 +53,30 @@
+
+ /* ─── Scene-specific padding & layout ────────────────────────────────────────── */
+
+-.sceneAutomation,
+-.sceneRobotics,
+-.sceneNeural {
+-  padding: 1rem 1rem 1.15rem;
++/* Scene grids focus entirely on visual impact */
++.sceneBody {
++  display: grid;
++  align-items: center;
++  min-height: 16rem; /* Enlarge slightly to let design shine */
++  gap: 2rem;
+ }
+
+-/* Automation: title LEFT, rig RIGHT */
+-
+-.sceneAutomation .sceneBody {
+-  grid-template-columns: minmax(0, 10.5rem) minmax(0, 1fr);
+-  align-items: center;
+-  min-height: 15rem;
+-  gap: 0.55rem;
+-}
+-
+-.sceneAutomation .titleBlock {
+-  max-width: 10.2rem;
+-  padding-left: 0.1rem;
+-  z-index: 2;
+-}
+-
+-.sceneAutomation .headlineWrap {
+-  grid-template-columns: 1fr;
+-  justify-items: start;
+-}
+-
+-.sceneAutomation .iconBadge {
+-  width: 2.5rem;
+-  height: 2.5rem;
+-  border-radius: 0.85rem;
+-}
+-
+-.sceneAutomation .titleLockup,
+-.sceneAutomation .descriptor {
+-  max-width: 10rem;
+-}
+-
+-.sceneAutomation .sceneRig {
+-  min-height: 14rem;
+-  border: none;
+-  background:
+-    radial-gradient(circle at 50% 44%, var(--perf-glow-soft), transparent 44%),
+-    linear-gradient(160deg, var(--perf-subtle-fill), transparent);
+-  overflow: visible;
+-}
+-
+-/* Robotics: rig LEFT, title RIGHT */
+-
+-.sceneRobotics .sceneBody {
+-  grid-template-columns: minmax(0, 1fr) minmax(0, 10rem);
+-  align-items: center;
+-  min-height: 15rem;
+-  gap: 0.55rem;
+-}
++.sceneAutomation .sceneBody { grid-template-columns: 1fr 1.5fr; }
++.sceneRobotics .sceneBody { grid-template-columns: 1fr 1.5fr; }
++.sceneNeural .sceneBody { grid-template-columns: 1.5fr 1fr; }
+
++/* In automation, robotics: text is second element in code, rig is first */
++.sceneAutomation .titleBlock,
+ .sceneRobotics .titleBlock {
+   order: 2;
+-  max-width: 9.8rem;
+-  justify-self: end;
+-  z-index: 2;
+-}
+-
+-.sceneRobotics .headlineWrap {
+-  grid-template-columns: 1fr;
+-  justify-items: start;
+-}
+-
+-.sceneRobotics .iconBadge {
+-  width: 2.5rem;
+-  height: 2.5rem;
+-  border-radius: 0.85rem;
+-}
+-
+-.sceneRobotics .titleLockup,
+-.sceneRobotics .descriptor {
+-  max-width: 9.6rem;
+ }
+
++.sceneAutomation .sceneRig,
+ .sceneRobotics .sceneRig {
+   order: 1;
+-  min-height: 14rem;
+-  border: none;
+-  background: none;
+-  overflow: visible;
+ }
+
+-/* Neural: title LEFT (narrow), rig RIGHT (wider) */
+-
+-.sceneNeural .sceneBody {
+-  grid-template-columns: minmax(0, 9.5rem) minmax(0, 1fr);
+-  align-items: center;
+-  min-height: 15rem;
+-  gap: 0.5rem;
++/* ─── Scene body / title block ─────────────────────────────────────────── */
++
++.titleBlock {
++  display: flex;
++  flex-direction: column;
++  justify-content: center;
++  z-index: 2;
+ }
+
+-.sceneNeural .titleBlock {
+-  max-width: 9.2rem;
+-  padding-left: 0.1rem;
+-  z-index: 2;
+-}
+-
+-.sceneNeural .headlineWrap {
+-  grid-template-columns: 1fr;
+-  justify-items: start;
+-}
+-
+-.sceneNeural .iconBadge {
+-  display: none;
+-}
+-
+-.sceneNeural .titleLockup,
+-.sceneNeural .descriptor {
+-  max-width: 9rem;
++.headlineWrap {
++  display: flex;
++  flex-direction: column;
++  align-items: center;
++  text-align: center;
++  gap: 1.5rem;
+ }
+
+-.sceneNeural .sceneRig {
+-  min-height: 14rem;
+-  border: none;
+-  background: none;
+-  overflow: visible;
+-  display: grid;
+-  place-items: center;
++/* Adjustments for layouts with rig left/right */
++.sceneAutomation .headlineWrap,
++.sceneRobotics .headlineWrap {
++  align-items: flex-start;
++  text-align: left;
+ }
+
+-/* ─── Deck ───────────────────────────────────────────────────────────────────── */
+-
+-.deck {
+-  display: grid;
+-  grid-template-columns: auto 1fr auto;
+-  align-items: center;
+-  gap: 0.8rem;
+-  margin-bottom: 0.95rem;
+-  color: var(--perf-muted);
+-  font-size: 0.62rem;
+-  letter-spacing: 0.22em;
+-  text-transform: uppercase;
+-}
+-
+-.deckFamily,
+-.deckCounter {
+-  white-space: nowrap;
+-}
+-
+-.deckCounter {
+-  justify-self: end;
+-}
+-
+-.deckCounterTotal {
+-  opacity: 0.65;
+-}
+-
+-.deckNotes {
+-  display: flex;
+-  flex-wrap: wrap;
+-  justify-content: center;
+-  gap: 0.38rem;
+-}
+-
+-.deckNote {
+-  border-radius: 999px;
+-  border: 1px solid var(--perf-edge);
+-  background: var(--perf-subtle-fill);
+-  padding: 0.22rem 0.5rem;
+-}
+-
+-/* ─── Scene body / title block ───────────────────────────────────────────────── */
+-
+-.sceneBody {
+-  display: grid;
+-  gap: 1rem;
+-}
+-
+-.titleBlock {
+-  display: grid;
+-  gap: 0.55rem;
+-}
+-
+-.kicker {
+-  color: var(--perf-muted);
+-  font-size: 0.66rem;
+-  letter-spacing: 0.24em;
+-  text-transform: uppercase;
+-}
+-
+-.headlineWrap {
+-  display: grid;
+-  grid-template-columns: auto 1fr;
+-  gap: 0.85rem;
+-  align-items: start;
++.sceneNeural .headlineWrap {
++  align-items: flex-start;
++  text-align: left;
+ }
+
+ .iconBadge {
+   display: inline-flex;
+   align-items: center;
+   justify-content: center;
+-  width: 3rem;
+-  height: 3rem;
+-  border-radius: 1rem;
++  width: 4.5rem; /* much larger */
++  height: 4.5rem;
++  border-radius: 1.25rem;
+   border: 1px solid var(--perf-edge);
+   background:
+     linear-gradient(160deg, var(--perf-fill-strong), var(--perf-fill)),
+     var(--perf-gradient);
+-  box-shadow: 0 18px 34px var(--perf-glow-soft);
++  box-shadow: 0 24px 48px var(--perf-glow-soft);
++  margin-bottom: 0.5rem;
+ }
+
+ .icon {
+-  width: 1.35rem;
+-  height: 1.35rem;
+-  color: var(--perf-text);
++  width: 2.2rem;
++  height: 2.2rem;
++  color: #fff;
++  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+ }
+
+ .titleLockup {
+-  display: grid;
+-  gap: 0.4rem;
++  display: flex;
++  flex-direction: column;
+ }
+
+ .title {
+   margin: 0;
+-  font-size: clamp(1.42rem, 3vw, 2.16rem);
+-  line-height: 0.96;
+-  letter-spacing: -0.035em;
++  font-size: clamp(2rem, 4.5vw, 3.2rem); /* Significantly enlarged */
++  line-height: 1.05;
++  letter-spacing: -0.04em;
+   text-wrap: balance;
+-}
+-
+-.descriptor {
+-  margin: 0;
+-  max-width: 30rem;
+-  color: var(--perf-muted);
+-  font-size: 0.87rem;
+-  line-height: 1.5;
++  text-shadow: 0 10px 30px var(--perf-glow-soft), 0 2px 4px rgba(0,0,0,0.5); /* Glowing and poppy text */
++  font-weight: 800;
++  background: linear-gradient(to bottom right, #fff, var(--perf-edge));
++  -webkit-background-clip: text;
++  -webkit-text-fill-color: transparent;
+ }

--- a/patch.py
+++ b/patch.py
@@ -1,0 +1,88 @@
+import re
+
+with open("components/landing-title/crafted.module.css", "r") as f:
+    content = f.read()
+
+# Replace Scene body to descriptor with the new stuff
+start_marker = "/* ─── Scene body / title block ─────────────────────────────────────────── */"
+end_marker = "/* ─── Rig base ─────────────────────────────────────────────────────────── */"
+
+new_css = """/* ─── Scene body / title block ─────────────────────────────────────────── */
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  z-index: 2;
+}
+
+.headlineWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+/* Adjustments for layouts with rig left/right */
+.sceneAlchemist .headlineWrap,
+.sceneCyberDefense .headlineWrap,
+.sceneBlockchain .headlineWrap {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.sceneDigitalSculptor .headlineWrap,
+.sceneHolographicSculptor .headlineWrap,
+.sceneFrontier .headlineWrap {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.iconBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 4.5rem; /* much larger */
+  height: 4.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--craft-edge);
+  background:
+    linear-gradient(160deg, var(--craft-fill-strong), var(--craft-fill)),
+    var(--craft-gradient);
+  box-shadow: 0 24px 48px var(--craft-glow-soft);
+  margin-bottom: 0.5rem;
+}
+
+.icon {
+  width: 2.2rem;
+  height: 2.2rem;
+  color: #fff;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+}
+
+.titleLockup {
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2rem, 4.5vw, 3.2rem); /* Significantly enlarged */
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  text-wrap: balance;
+  text-shadow: 0 10px 30px var(--craft-glow-soft), 0 2px 4px rgba(0,0,0,0.5); /* Glowing and poppy text */
+  font-weight: 800;
+  background: linear-gradient(to bottom right, #fff, var(--craft-edge));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+"""
+
+pattern = re.compile(re.escape(start_marker) + r".*?" + re.escape(end_marker), re.DOTALL)
+content = pattern.sub(new_css + end_marker, content)
+
+with open("components/landing-title/crafted.module.css", "w") as f:
+    f.write(content)

--- a/patch_arcane.py
+++ b/patch_arcane.py
@@ -1,0 +1,15 @@
+import re
+
+with open('components/landing-title/arcane.module.css', 'r') as f:
+    content = f.read()
+
+# Make arcane rigs have the same exact centering and flex properties as systems and crafted
+# if they don't already have it
+content = re.sub(
+    r'\.sceneRig \{\s*min-height: 16rem;\s*flex-shrink: 0;\s*\}',
+    '.sceneRig {\n  min-height: 16rem;\n  flex-shrink: 0;\n  position: relative;\n}',
+    content
+)
+
+with open('components/landing-title/arcane.module.css', 'w') as f:
+    f.write(content)

--- a/patch_arcane_layout.py
+++ b/patch_arcane_layout.py
@@ -1,0 +1,45 @@
+import re
+
+with open("components/landing-title/arcane.module.css", "r") as f:
+    content = f.read()
+
+start_marker = "/* ─── Scene body layout overrides ──────────────────────────────────────── */"
+end_marker = "/* ─── Scene body / title block ─────────────────────────────────────────── */"
+
+new_css = """/* ─── Scene body layout overrides ──────────────────────────────────────── */
+
+/* Scene grids focus entirely on visual impact */
+.sceneBody {
+  display: grid;
+  align-items: center;
+  min-height: 16rem; /* Enlarge slightly to let design shine */
+  gap: 2rem;
+}
+
+/* Scene column sizing for visual balance */
+.sceneSorcerer .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneMage .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneWeaver .sceneBody { grid-template-columns: 1.5fr 1fr; }
+.sceneConjurer .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneMystic .sceneBody { grid-template-columns: 1.5fr 1fr; }
+.sceneOracle .sceneBody { grid-template-columns: 1.5fr 1fr; }
+
+/* In sorcerer, mage, conjurer: text is second element in code, rig is first */
+.sceneSorcerer .titleBlock,
+.sceneMage .titleBlock,
+.sceneConjurer .titleBlock {
+  order: 2;
+}
+
+.sceneSorcerer .sceneRig,
+.sceneMage .sceneRig,
+.sceneConjurer .sceneRig {
+  order: 1;
+}
+
+"""
+pattern = re.compile(re.escape(start_marker) + r".*?" + re.escape(end_marker), re.DOTALL)
+content = pattern.sub(new_css + end_marker, content)
+
+with open("components/landing-title/arcane.module.css", "w") as f:
+    f.write(content)

--- a/patch_arcane_title.py
+++ b/patch_arcane_title.py
@@ -1,0 +1,86 @@
+import re
+
+with open("components/landing-title/arcane.module.css", "r") as f:
+    content = f.read()
+
+start_marker = "/* ─── Scene body / title block ─────────────────────────────────────────── */"
+end_marker = "/* ─── Rig base ─────────────────────────────────────────────────────────── */"
+
+new_css = """/* ─── Scene body / title block ─────────────────────────────────────────── */
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  z-index: 2;
+}
+
+.headlineWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+/* Adjustments for layouts with rig left/right */
+.sceneSorcerer .headlineWrap,
+.sceneMage .headlineWrap,
+.sceneConjurer .headlineWrap {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.sceneWeaver .headlineWrap,
+.sceneMystic .headlineWrap,
+.sceneOracle .headlineWrap {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.iconBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 4.5rem; /* much larger */
+  height: 4.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--arc-edge);
+  background:
+    linear-gradient(160deg, var(--arc-overlay-bold), var(--arc-overlay)),
+    var(--arc-gradient);
+  box-shadow: 0 24px 48px var(--arc-glow-soft);
+  margin-bottom: 0.5rem;
+}
+
+.icon {
+  width: 2.2rem;
+  height: 2.2rem;
+  color: #fff;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+}
+
+.titleLockup {
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2rem, 4.5vw, 3.2rem); /* Significantly enlarged */
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  text-wrap: balance;
+  text-shadow: 0 10px 30px var(--arc-glow-soft), 0 2px 4px rgba(0,0,0,0.5); /* Glowing and poppy text */
+  font-weight: 800;
+  background: linear-gradient(to bottom right, #fff, var(--arc-edge));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+"""
+pattern = re.compile(re.escape(start_marker) + r".*?" + re.escape(end_marker), re.DOTALL)
+content = pattern.sub(new_css + end_marker, content)
+
+with open("components/landing-title/arcane.module.css", "w") as f:
+    f.write(content)

--- a/patch_layout.py
+++ b/patch_layout.py
@@ -1,0 +1,40 @@
+import re
+
+with open("components/landing-title/crafted.module.css", "r") as f:
+    content = f.read()
+
+start_marker = "/* ─── Scene body layout overrides ──────────────────────────────────────── */"
+end_marker = "/* ─── Scene body / title block ─────────────────────────────────────────── */"
+
+new_css = """/* ─── Scene body layout overrides ──────────────────────────────────────── */
+
+/* Scene grids focus entirely on visual impact */
+.sceneBody {
+  display: grid;
+  align-items: center;
+  min-height: 16rem; /* Enlarge slightly to let design shine */
+  gap: 2rem;
+}
+
+.sceneAlchemist .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneDigitalSculptor .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneHolographicSculptor .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneCyberDefense .sceneBody { grid-template-columns: 1fr 1.5fr; }
+.sceneBlockchain .sceneBody { grid-template-columns: 1.5fr 1fr; }
+.sceneFrontier .sceneBody { grid-template-columns: 1fr 1.5fr; }
+
+/* In blockchain: text is second element in code, rig is first */
+.sceneBlockchain .titleBlock {
+  order: 2;
+}
+
+.sceneBlockchain .sceneRig {
+  order: 1;
+}
+
+"""
+pattern = re.compile(re.escape(start_marker) + r".*?" + re.escape(end_marker), re.DOTALL)
+content = pattern.sub(new_css + end_marker, content)
+
+with open("components/landing-title/crafted.module.css", "w") as f:
+    f.write(content)


### PR DESCRIPTION
Refined the landing page rotating subtitles. The secondary text has been stripped out, leaving only the professional title and its associated visual rig. The text styling and visual prominence of the components have been heavily increased.

---
*PR created automatically by Jules for task [6282000015325471569](https://jules.google.com/task/6282000015325471569) started by @wyattowalsh*

## Summary by Sourcery

Refine the landing page rotating professional titles to focus on bold, visually prominent title-and-rig scenes without secondary copy.

Enhancements:
- Redesign all landing title scenes (systems, performance, arcane, crafted) to enlarge and center the primary title, increase icon and rig prominence, and simplify layouts for stronger visual impact.
- Unify scene grid, headline, and title block layouts across themes with clearer left/right rig-title positioning and improved mobile single-column behavior.
- Remove auxiliary subtitle elements such as decks, kickers, and descriptive body text so each scene presents only the core professional title plus its visual rig.

Chores:
- Regenerate particle configuration metadata with updated timestamps and add helper patch scripts used to transform landing-title CSS files.